### PR TITLE
Fixed the comment keybinding

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,9 +1,7 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
-        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "/*", "*/" ]
+        "lineComment": "#"
     },
     // symbols used as brackets
     "brackets": [


### PR DESCRIPTION
In vscode you can press ctrl+/ for example on windows to comment the line or the block of lines.

This extension had it set to using `//` as the comment character, which should be `#`.

Removing the block comment section as well allows you to comment each line separately with the `#` character.